### PR TITLE
Added the token to the caching hash

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -238,9 +238,9 @@ class API
 
         // This identifies a unique request
         if (extension_loaded('sodium')) {
-            $api_request_hash = bin2hex(sodium_crypto_generichash($api_request));
+            $api_request_hash = bin2hex(sodium_crypto_generichash($api_request . $this->access_token));
         } else {
-            $api_request_hash = md5($api_request);
+            $api_request_hash = md5($api_request . $this->access_token);
         }
 
         // Check if this request exists in the cache and if so, return it directly -


### PR DESCRIPTION
This fixes a problem where if a code stub runs on multiple access tokens the cache will not re query the API on the same request but a different token is passed in; due to the static nature of the cache its share between all instances. Adding the access token to the caching hash will separate different users requests and prevent the first person's queried data being used for all subsequent users.