### PR TITLE
Add .gitattributes with excluding non-dev files to Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+.gitattributes export-ignore
+.github export-ignore
+.travis.yml export-ignore
+examples export-ignore
+phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore
+psalm.xml export-ignore
+tests export-ignore


### PR DESCRIPTION
Composer package of this library now contains lot of files which has no sense for library-context. They are usable only during developing this library, but when is library used inside another project, it's just mess.

This PR as adding the [`export-ignore` rule](https://www.git-scm.com/docs/gitattributes#_export_ignore) for files which has sense for library developer context only. That's cause to remove these files from finally package in Composer repository.

Read more about this feature at article: [GitAttributes for PHP Composer Projects](https://php.watch/articles/composer-gitattributes).